### PR TITLE
Support Jenkins Pipelines

### DIFF
--- a/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonStudioTask.java
+++ b/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonStudioTask.java
@@ -5,18 +5,19 @@ import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
+import hudson.model.*;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
+import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 
-public class ExecuteKatalonStudioTask extends Builder {
+public class ExecuteKatalonStudioTask extends Builder implements SimpleBuildStep {
 
     private String version;
 
@@ -85,14 +86,27 @@ public class ExecuteKatalonStudioTask extends Builder {
     @Override
     public boolean perform(AbstractBuild<?, ?> abstractBuild, Launcher launcher, BuildListener buildListener)
         throws InterruptedException, IOException {
-
         FilePath workspace = abstractBuild.getWorkspace();
         EnvVars buildEnvironment = abstractBuild.getEnvironment(buildListener);
+        return doPerform(workspace, buildEnvironment, launcher, buildListener);
+    }
+
+    @Override
+    public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher,
+                        @Nonnull TaskListener taskListener)
+        throws InterruptedException, IOException {
+        EnvVars buildEnvironment = run.getEnvironment(taskListener);
+        doPerform(filePath, buildEnvironment, launcher, taskListener);
+    }
+
+    private boolean doPerform(FilePath workspace, EnvVars buildEnvironment,
+                              Launcher launcher, TaskListener taskListener)
+        throws IOException, InterruptedException {
         return ExecuteKatalonStudioHelper.executeKatalon(
             workspace,
             buildEnvironment,
             launcher,
-            buildListener,
+            taskListener,
             version,
             location,
             executeArgs,
@@ -100,6 +114,7 @@ public class ExecuteKatalonStudioTask extends Builder {
             xvfbConfiguration);
     }
 
+    @Symbol("executeKatalon")
     @Extension
     public static class DescriptorImpl extends BuildStepDescriptor<Builder> { // Publisher because Notifiers are a type of publisher
         @Override

--- a/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonTestOpsPlan.java
+++ b/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonTestOpsPlan.java
@@ -11,11 +11,9 @@ import com.katalon.jenkins.plugin.helper.KatalonTestOpsSearchHelper;
 import com.katalon.jenkins.plugin.helper.JenkinsLogger;
 import com.katalon.utils.Logger;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
-import hudson.model.BuildListener;
-import hudson.model.Item;
+import hudson.model.*;
 import hudson.security.ACL;
 import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.BuildStepMonitor;
@@ -23,19 +21,21 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerRequest;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
-public class ExecuteKatalonTestOpsPlan extends Builder {
+public class ExecuteKatalonTestOpsPlan extends Builder implements SimpleBuildStep {
 
   private String apiKey;
 
@@ -92,7 +92,18 @@ public class ExecuteKatalonTestOpsPlan extends Builder {
   @Override
   public boolean perform(AbstractBuild<?, ?> abstractBuild, Launcher launcher, BuildListener buildListener)
       throws InterruptedException, IOException {
-    Logger logger = new JenkinsLogger(buildListener);
+    return doPerform(buildListener);
+  }
+
+  @Override
+  public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath,
+                      @Nonnull Launcher launcher, @Nonnull TaskListener taskListener)
+      throws InterruptedException, IOException {
+    doPerform(taskListener);
+  }
+
+  private boolean doPerform(TaskListener taskListener) {
+    Logger logger = new JenkinsLogger(taskListener);
     KatalonTestOpsHelper katalonAnalyticsHandler = new KatalonTestOpsHelper(logger);
     return katalonAnalyticsHandler.run(serverUrl, apiKey, plan, projectId);
   }
@@ -102,6 +113,7 @@ public class ExecuteKatalonTestOpsPlan extends Builder {
     return BuildStepMonitor.BUILD;
   }
 
+  @Symbol("executeKatalonTestOpsPlan")
   @Extension
   public static class DescriptorImpl extends BuildStepDescriptor<Builder> { // Publisher because Notifiers are a type of publisher
 

--- a/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonTestOpsPlan.java
+++ b/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonTestOpsPlan.java
@@ -12,6 +12,7 @@ import com.katalon.jenkins.plugin.helper.KatalonTestOpsSearchHelper;
 import com.katalon.jenkins.plugin.helper.JenkinsLogger;
 import com.katalon.utils.Logger;
 import hudson.Extension;
+import hudson.FilePath;
 import hudson.Launcher;
 import hudson.Util;
 import hudson.model.*;
@@ -23,17 +24,20 @@ import hudson.tasks.Builder;
 import hudson.util.FormValidation;
 import hudson.util.ListBoxModel;
 import jenkins.model.Jenkins;
+import jenkins.tasks.SimpleBuildStep;
 import net.sf.json.JSONObject;
 import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.*;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-public class ExecuteKatalonTestOpsPlan extends Builder {
+public class ExecuteKatalonTestOpsPlan extends Builder implements SimpleBuildStep {
 
   private String credentialsId;
 
@@ -112,7 +116,16 @@ public class ExecuteKatalonTestOpsPlan extends Builder {
   @Override
   public boolean perform(AbstractBuild<?, ?> abstractBuild, Launcher launcher, BuildListener buildListener)
       throws InterruptedException, IOException {
-    Logger logger = new JenkinsLogger(buildListener);
+    return doPerform(buildListener);
+  }
+
+  @Override
+  public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher, @Nonnull TaskListener taskListener) throws InterruptedException, IOException {
+    doPerform(taskListener);
+  }
+
+  private boolean doPerform(TaskListener taskListener) {
+    Logger logger = new JenkinsLogger(taskListener);
     KatalonTestOpsHelper katalonAnalyticsHandler = new KatalonTestOpsHelper(logger);
     return katalonAnalyticsHandler.run(serverUrl, apiKey, plan, projectId);
   }
@@ -122,6 +135,7 @@ public class ExecuteKatalonTestOpsPlan extends Builder {
     return BuildStepMonitor.BUILD;
   }
 
+  @Symbol("executeKatalonTestOps")
   @Extension
   public static class DescriptorImpl extends BuildStepDescriptor<Builder> { // Publisher because Notifiers are a type of publisher
 

--- a/src/main/java/com/katalon/jenkins/plugin/helper/ExecuteKatalonStudioHelper.java
+++ b/src/main/java/com/katalon/jenkins/plugin/helper/ExecuteKatalonStudioHelper.java
@@ -6,7 +6,7 @@ import com.katalon.utils.Logger;
 import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 import hudson.remoting.Callable;
 import org.jenkinsci.remoting.RoleChecker;
 
@@ -19,19 +19,19 @@ public class ExecuteKatalonStudioHelper {
             FilePath workspace,
             EnvVars buildEnvironment,
             Launcher launcher,
-            BuildListener buildListener,
+            TaskListener taskListener,
             String version,
             String location,
             String executeArgs,
             String x11Display,
             String xvfbConfiguration) {
-        Logger logger = new JenkinsLogger(buildListener);
+        Logger logger = new JenkinsLogger(taskListener);
         try {
             return launcher.getChannel().call(new Callable<Boolean, Exception>() {
                 @Override
                 public Boolean call() throws Exception {
 
-                    Logger logger = new JenkinsLogger(buildListener);
+                    Logger logger = new JenkinsLogger(taskListener);
 
                     if (workspace != null) {
                         String workspaceLocation = workspace.getRemote();

--- a/src/main/java/com/katalon/jenkins/plugin/helper/JenkinsLogger.java
+++ b/src/main/java/com/katalon/jenkins/plugin/helper/JenkinsLogger.java
@@ -1,21 +1,21 @@
 package com.katalon.jenkins.plugin.helper;
 
 import com.katalon.utils.Logger;
-import hudson.model.BuildListener;
+import hudson.model.TaskListener;
 
 import java.time.LocalDateTime;
 
 public class JenkinsLogger implements Logger {
 
-    private BuildListener buildListener;
+    private TaskListener taskListener;
 
-    public JenkinsLogger(BuildListener buildListener) {
-        this.buildListener = buildListener;
+    public JenkinsLogger(TaskListener taskListener) {
+        this.taskListener = taskListener;
     }
 
     @Override
     public void info(String message) {
         String timeNow = LocalDateTime.now().toString();
-        buildListener.getLogger().println('[' + timeNow + "] " + message);
+        taskListener.getLogger().println('[' + timeNow + "] " + message);
     }
 }

--- a/src/test/java/com/katalon/jenkins/plugin/DummyTest.java
+++ b/src/test/java/com/katalon/jenkins/plugin/DummyTest.java
@@ -1,0 +1,14 @@
+package com.katalon.jenkins.plugin;
+
+import org.junit.Test;
+
+public class DummyTest {
+    @Test
+    public void dummyTest() {
+        /*
+        This is a do-nothing test case to by pass Jenkins build error, without this, Jenkins will complain:
+            No test report files were found. Configuration error?
+        Please help to remove this once we have the first test
+        */
+    }
+}


### PR DESCRIPTION
Allow the tasks to be called from Pipeline scripts by:

- Implementing SimpleBuildStep interface
- Adding @Symbol annotation to the Descriptors
- Adjusting JenkinsLogger to receive TaskListener in its constructor instead of BuildListener, a subclass of TaskListener